### PR TITLE
Include Rust benchmark with arkworks && noadx flag for Go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 bench-go:
-	go test . -run=none -bench=.
+	go test . -run=none -bench=. -benchmem
+.PHONY: bench-go
+
+bench-go-noadx:
+	go test -tags noadx . -run=none -bench=BenchmarkFp -benchmem
 
 bench-blst:
 	cd blst-bench && ([ -f libblst.a ] || (git clone https://github.com/supranational/blst.git && ./blst/build.sh ; rm -rf blst))
 	cd blst-bench && cc -I . main.c libblst.a -o main && ./main && rm main
-    
+.PHONY: bench-blst
+
+bench-arkworks:
+	cd bench-arkworks && cargo install -q cargo-criterion && cargo criterion
+.PHONY: bench-arkworks

--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ This repository contains multiple benchmarks that are relevant to compare a Merk
 
 ## Run
 
-To run the benchmarks you need the Go and C compiler installed, and run:
+To run the benchmarks you need the Go, C, and Rust compilers installed, and run:
 
-- `make bench-go` for the Go benchmarks.
-- `make bench-blst` for the C blst benchmarks. It will automatically download & compile blst if needed.
+- `make bench-go`: to run the Go benchmarks.
+- `make bench-blst`: to run the C benchmarks.
+- `make bench-arkworks`: to run the Rust benchmarks.
 
 ## Benchmark results
 
 ### AMD Ryzen 7 3800XT 8-Core Processor
 
-Go benchmarks:
+Go benchmarks (with _Intel ADX_ CPU instructions):
 ```
 goos: linux
 goarch: amd64
@@ -49,14 +50,29 @@ BenchmarkHashStorageSlot/keccak-16                               2706037        
 BenchmarkHashStorageSlot/pedersen_hash-16                         133964              8609 ns/op             416 B/op         11 allocs/op
 ```
 
+Go (without _Intel ADX_ CPU instructions):
+```
+BenchmarkFpInverse/go-ipa-16              705946              1629 ns/op               0 B/op          0 allocs/op
+BenchmarkFpInverse/go-blst-16             714726              1427 ns/op              32 B/op          1 allocs/op
+BenchmarkFpMul/go-ipa-16                41319416                24.52 ns/op            0 B/op          0 allocs/op
+BenchmarkFpMul/go-blst-16               10759808               110.6 ns/op             0 B/op          0 allocs/op
+```
+
 C BLST benchmark:
 ```
 Inv(x) takes 1314 ns/op
 Mul(a,b) takes 73 ns/op
 ```
 
+Rust `arkworks-rs` benchmarks:
+```
+inverse                 time:   [2.1817 µs 2.1942 µs 2.2123 µs]                     
+mul                     time:   [16.340 ns 16.414 ns 16.504 ns]                 
+```
+
 ### Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
-Go benchmarks:
+
+Go benchmarks (with _Intel ADX_ CPU instructions):
 
 ```
 goos: darwin
@@ -93,8 +109,17 @@ BenchmarkHashStorageSlot/keccak-8                                2643908        
 BenchmarkHashStorageSlot/pedersen_hash-8                          130675              9139 ns/op             416 B/op         11 allocs/op
 ```
 
+Go (without _Intel ADX_ CPU instructions):
+```
+```
+
 C BLST benchmark:
 ```
 Inv(x) takes 1418 ns/op
 Mul(a,b) takes 142 ns/op
+```
+
+
+Rust `arkworks-rs` benchmarks:
+```
 ```

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ BenchmarkHashStorageSlot/pedersen_hash-8                          130675        
 
 Go (without _Intel ADX_ CPU instructions):
 ```
+BenchmarkFpInverse/go-ipa-8               563982              2384 ns/op               0 B/op          0 allocs/op
+BenchmarkFpInverse/go-blst-8              655209              2146 ns/op              32 B/op          1 allocs/op
+BenchmarkFpMul/go-ipa-8                 39916938                34.68 ns/op            0 B/op          0 allocs/op
+BenchmarkFpMul/go-blst-8                 8970868               133.3 ns/op             0 B/op          0 allocs/op
 ```
 
 C BLST benchmark:
@@ -119,7 +123,8 @@ Inv(x) takes 1418 ns/op
 Mul(a,b) takes 142 ns/op
 ```
 
-
 Rust `arkworks-rs` benchmarks:
 ```
+inverse                 time:   [2.0268 µs 2.0381 µs 2.0498 µs]
+mul                     time:   [23.864 ns 24.053 ns 24.313 ns]
 ```

--- a/bench-arkworks/.gitignore
+++ b/bench-arkworks/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/bench-arkworks/Cargo.toml
+++ b/bench-arkworks/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bench-arkworks"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ark-bls12-381 = "0.3.0"
+ark-ff = { version = "0.3.0", features = [ "asm" ] }
+ark-std = "0.3.0"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "invmul"
+harness = false

--- a/bench-arkworks/benches/invmul.rs
+++ b/bench-arkworks/benches/invmul.rs
@@ -1,0 +1,28 @@
+use ark_bls12_381::fr::Fr;
+use ark_ff::Field;
+use ark_std::{
+    rand::{rngs::StdRng, SeedableRng},
+    UniformRand,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::ops::Mul;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut x = Fr::rand(&mut rng);
+    let y = Fr::rand(&mut rng);
+
+    c.bench_function("inverse", |b| {
+        b.iter(|| {
+            x = x.inverse().unwrap();
+        })
+    });
+    c.bench_function("mul", |b| {
+        b.iter(|| {
+            x = x.mul(y);
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/triekeyhash_test.go
+++ b/triekeyhash_test.go
@@ -16,11 +16,12 @@ func BenchmarkHashAddress(b *testing.B) {
 	_, err := rand.Read(addrBytes[:])
 	require.NoError(b, err)
 
+	// Warmup go-ipa generating precomputes before main bench.
+	sink = verkleutils.GetTreeKeyBalance(addrBytes)
+
 	b.Run("keccak", benchKeccak(addrBytes))
 	b.Run("pedersen hash", func(b *testing.B) {
 		var res []byte
-		// Warmup go-ipa generating precomputes before main bench.
-		res = verkleutils.GetTreeKeyBalance(addrBytes)
 
 		b.ReportAllocs()
 		b.ResetTimer()


### PR DESCRIPTION
This PR:
- Adds an extra benchmark for Inv and Mul using arkworks with Rust.
- Adds a Go benchmark flavor to disallow the use of [Intel ADX](https://en.wikipedia.org/wiki/Intel_ADX) CPU instructions.
- Updates the README with the new results for both setups.