### PR TITLE
go-ipa: use more performant Inverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,46 +16,42 @@ To run the benchmarks you need the Go, C, and Rust compilers installed, and run:
 
 Go benchmarks (with _Intel ADX_ CPU instructions):
 ```
-goos: linux
-goarch: amd64
-pkg: github.com/jsign/keccak-vs-pedersen
-cpu: AMD Ryzen 7 3800XT 8-Core Processor            
-BenchmarkFpInverse/go-ipa-16                      722480              1665 ns/op               0 B/op          0 allocs/op
-BenchmarkFpInverse/go-blst-16                     831808              1406 ns/op              32 B/op          1 allocs/op
-BenchmarkFpMul/go-ipa-16                        78093471                14.87 ns/op            0 B/op          0 allocs/op
-BenchmarkFpMul/go-blst-16                       10473631               113.0 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=32-16                       2707854               440.5 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=64-16                       2905962               412.9 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=128-16                      3171886               372.5 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=256-16                      1715360               685.3 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=512-16                       893442              1336 ns/op               0 B/op          0 allocs/op
-BenchmarkKeccak/size=1024-16                      397701              2888 ns/op               0 B/op          0 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=1-16              29551             39907 ns/op             39907 ns/value        33929 B/op         19 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=2-16              25261             47237 ns/op             23619 ns/value        33937 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=4-16              19268             60985 ns/op             15247 ns/value        33920 B/op         18 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=8-16              13380             90209 ns/op             11276 ns/value        33929 B/op         19 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=16-16              8083            147664 ns/op              9229 ns/value        33937 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=32-16              4119            265643 ns/op              8301 ns/value        33930 B/op         19 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=64-16              2246            491729 ns/op              7683 ns/value        33929 B/op         19 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=128-16             1119            986195 ns/op              7705 ns/value        33932 B/op         19 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=256-16              598           1904488 ns/op              7440 ns/value        33943 B/op         20 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=1-16             82398             13985 ns/op             368 B/op          7 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=4-16             87585             13944 ns/op             368 B/op          7 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=16-16            83296             14103 ns/op             376 B/op          8 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=64-16            86702             13843 ns/op             368 B/op          7 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=256-16           81349             13784 ns/op             368 B/op          7 allocs/op
-BenchmarkHashAddress/keccak-16                                   2691130               445.9 ns/op             0 B/op          0 allocs/op
-BenchmarkHashAddress/pedersen_hash-16                             160214              6766 ns/op             160 B/op          3 allocs/op
-BenchmarkHashStorageSlot/keccak-16                               2706037               442.7 ns/op             0 B/op          0 allocs/op
-BenchmarkHashStorageSlot/pedersen_hash-16                         133964              8609 ns/op             416 B/op         11 allocs/op
+BenchmarkFpInverse/go-ipa-16                     1048089              1116 ns/op               0 B/op          0 allocs/op
+BenchmarkFpInverse/go-blst-16                     834487              1409 ns/op              32 B/op          1 allocs/op
+BenchmarkFpMul/go-ipa-16                        79013084                14.83 ns/op            0 B/op          0 allocs/op
+BenchmarkFpMul/go-blst-16                        9497001               108.3 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=32-16                       2811439               406.0 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=64-16                       3040315               395.3 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=128-16                      3415230               349.8 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=256-16                      1752966               661.4 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=512-16                       904863              1325 ns/op               0 B/op          0 allocs/op
+BenchmarkKeccak/size=1024-16                      383635              2620 ns/op               0 B/op          0 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=1-16              30967             38261 ns/op             38261 ns/value   33937 B/op          20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=2-16              25597             45282 ns/op             22641 ns/value   33937 B/op          20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=4-16              19479             59399 ns/op             14850 ns/value   33937 B/op          20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=8-16              13435             87227 ns/op             10903 ns/value   33937 B/op          20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=16-16              8191            144080 ns/op              9005 ns/value   33937 B/op          20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=32-16              4604            264342 ns/op              8261 ns/value   33937 B/op          20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=64-16              2194            486668 ns/op              7604 ns/value   33930 B/op          19 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=128-16             1051            982158 ns/op              7673 ns/value   33940 B/op          20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=256-16              602           1935915 ns/op              7562 ns/value   33951 B/op          21 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=1-16            132586              8819 ns/op             376 B/op              8 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=4-16            128914              8798 ns/op             376 B/op              8 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=16-16           130920              8826 ns/op             376 B/op              8 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=64-16           124934              8804 ns/op             376 B/op              8 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=256-16          135568              8607 ns/op             368 B/op              7 allocs/op
+BenchmarkHashAddress/keccak-16                                   2738773               427.8 ns/op             0 B/op              0 allocs/op
+BenchmarkHashAddress/pedersen_hash-16                             176554              6162 ns/op             160 B/op              3 allocs/op
+BenchmarkHashStorageSlot/keccak-16                               2821916               429.1 ns/op             0 B/op              0 allocs/op
+BenchmarkHashStorageSlot/pedersen_hash-16                         142660              7916 ns/op             416 B/op             11 allocs/op
 ```
 
 Go (without _Intel ADX_ CPU instructions):
 ```
-BenchmarkFpInverse/go-ipa-16              705946              1629 ns/op               0 B/op          0 allocs/op
-BenchmarkFpInverse/go-blst-16             714726              1427 ns/op              32 B/op          1 allocs/op
-BenchmarkFpMul/go-ipa-16                41319416                24.52 ns/op            0 B/op          0 allocs/op
-BenchmarkFpMul/go-blst-16               10759808               110.6 ns/op             0 B/op          0 allocs/op
+BenchmarkFpInverse/go-ipa-16             1030958              1168 ns/op               0 B/op          0 allocs/op
+BenchmarkFpInverse/go-blst-16             870020              1391 ns/op              32 B/op          1 allocs/op
+BenchmarkFpMul/go-ipa-16                40603137                24.69 ns/op            0 B/op          0 allocs/op
+BenchmarkFpMul/go-blst-16               10218465               113.1 ns/op             0 B/op          0 allocs/op
 ```
 
 C BLST benchmark:
@@ -75,46 +71,42 @@ mul                     time:   [16.340 ns 16.414 ns 16.504 ns]
 Go benchmarks (with _Intel ADX_ CPU instructions):
 
 ```
-goos: darwin
-goarch: amd64
-pkg: github.com/jsign/verkle-vs-patricia
-cpu: Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
-BenchmarkFpInverse/go-ipa-8               618098              1866 ns/op               0 B/op          0 allocs/op
-BenchmarkFpInverse/go-blst-8              798846              1501 ns/op              32 B/op          1 allocs/op
-BenchmarkFpMul/go-ipa-8                 72805527                16.61 ns/op            0 B/op          0 allocs/op
-BenchmarkFpMul/go-blst-8                 9406170               118.5 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=32-8                2694834               442.2 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=64-8                2566628               424.5 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=128-8               2991798               388.3 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=256-8               1601151               747.5 ns/op             0 B/op          0 allocs/op
-BenchmarkKeccak/size=512-8                817632              1459 ns/op               0 B/op          0 allocs/op
-BenchmarkKeccak/size=1024-8               414661              2900 ns/op               0 B/op          0 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=1-8               28960             41144 ns/op             41146 ns/value        33937 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=2-8               23982             47916 ns/op             23960 ns/value        33936 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=4-8               18398             63763 ns/op             15942 ns/value        33936 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=8-8               12680             93300 ns/op             11663 ns/value        33936 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=16-8               7726            157905 ns/op              9870 ns/value        33937 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=32-8               4231            283232 ns/op              8851 ns/value        33937 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=64-8               2155            533065 ns/op              8329 ns/value        33929 B/op         19 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=128-8              1032           1029765 ns/op              8045 ns/value        33939 B/op         20 allocs/op
-BenchmarkPedersenCommit/non_zero_entries=256-8               538           2283879 ns/op              8922 ns/value        33948 B/op         21 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=1-8              67816             17282 ns/op             376 B/op          8 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=4-8              70353             17237 ns/op             376 B/op          8 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=16-8             69090             16906 ns/op             376 B/op          8 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=64-8             67299             16929 ns/op             376 B/op          8 allocs/op
-BenchmarkPedersenUpdateCommitment/vec_num_entries=256-8            71257             18147 ns/op             368 B/op          7 allocs/op
-BenchmarkHashAddress/keccak-8                                    2593776               454.6 ns/op             0 B/op          0 allocs/op
-BenchmarkHashAddress/pedersen_hash-8                              164329              7201 ns/op             160 B/op          3 allocs/op
-BenchmarkHashStorageSlot/keccak-8                                2643908               445.3 ns/op             0 B/op          0 allocs/op
-BenchmarkHashStorageSlot/pedersen_hash-8                          130675              9139 ns/op             416 B/op         11 allocs/op
+BenchmarkFpInverse/go-ipa-8               807909              1406 ns/op               0 B/op          0 allocs/op
+BenchmarkFpInverse/go-blst-8              692365              1557 ns/op              32 B/op          1 allocs/op
+BenchmarkFpMul/go-ipa-8                 65012094                17.57 ns/op            0 B/op          0 allocs/op
+BenchmarkFpMul/go-blst-8                 9384998               126.2 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=32-8                2491617               470.7 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=64-8                2692922               442.9 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=128-8               2892056               411.3 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=256-8               1511790               790.1 ns/op             0 B/op          0 allocs/op
+BenchmarkKeccak/size=512-8                699243              1562 ns/op               0 B/op          0 allocs/op
+BenchmarkKeccak/size=1024-8               361258              3070 ns/op               0 B/op          0 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=1-8               28230             42195 ns/op             42197 ns/value        33937 B/op         20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=2-8               24967             46683 ns/op             23343 ns/value        33936 B/op         20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=4-8               19010             62857 ns/op             15715 ns/value        33936 B/op         20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=8-8               12634             92911 ns/op             11614 ns/value        33936 B/op         20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=16-8               7234            155541 ns/op              9722 ns/value        33936 B/op         20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=32-8               3674            281022 ns/op              8782 ns/value        33936 B/op         20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=64-8               1977            532915 ns/op              8327 ns/value        33929 B/op         19 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=128-8              1077           1036918 ns/op              8102 ns/value        33938 B/op         20 allocs/op
+BenchmarkPedersenCommit/non_zero_entries=256-8               565           2033419 ns/op              7943 ns/value        33948 B/op         21 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=1-8             109887             11084 ns/op             376 B/op          8 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=4-8              98496             11511 ns/op             376 B/op          8 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=16-8            110120             11647 ns/op             376 B/op          8 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=64-8             94174             11570 ns/op             376 B/op          8 allocs/op
+BenchmarkPedersenUpdateCommitment/vec_num_entries=256-8           106506             10452 ns/op             368 B/op          7 allocs/op
+BenchmarkHashAddress/keccak-8                                    2528505               469.1 ns/op             0 B/op          0 allocs/op
+BenchmarkHashAddress/pedersen_hash-8                              165478              7131 ns/op             160 B/op          3 allocs/op
+BenchmarkHashStorageSlot/keccak-8                                2419062               512.0 ns/op             0 B/op          0 allocs/op
+BenchmarkHashStorageSlot/pedersen_hash-8                          121276              9981 ns/op             416 B/op         11 allocs/op
 ```
 
 Go (without _Intel ADX_ CPU instructions):
 ```
-BenchmarkFpInverse/go-ipa-8               563982              2384 ns/op               0 B/op          0 allocs/op
-BenchmarkFpInverse/go-blst-8              655209              2146 ns/op              32 B/op          1 allocs/op
-BenchmarkFpMul/go-ipa-8                 39916938                34.68 ns/op            0 B/op          0 allocs/op
-BenchmarkFpMul/go-blst-8                 8970868               133.3 ns/op             0 B/op          0 allocs/op
+BenchmarkFpInverse/go-ipa-8               825962              1424 ns/op               0 B/op          0 allocs/op
+BenchmarkFpInverse/go-blst-8              648957              1658 ns/op              32 B/op          1 allocs/op
+BenchmarkFpMul/go-ipa-8                 39319251                33.39 ns/op            0 B/op          0 allocs/op
+BenchmarkFpMul/go-blst-8                 7675392               134.8 ns/op             0 B/op          0 allocs/op
 ```
 
 C BLST benchmark:

--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,7 @@ require (
 
 // References https://github.com/gballet/go-ethereum/tree/beverly-hills-head, to have GetTreeKey func.
 replace github.com/ethereum/go-ethereum => github.com/gballet/go-ethereum v1.10.24-0.20221005144906-f0e4ab07b54a
+
+// References https://github.com/jsign/go-ipa/tree/jsign/upinv.
+// Remove this `replace` if the underlying PR get's merged.
+replace github.com/crate-crypto/go-ipa => github.com/jsign/go-ipa v0.0.0-20221107222631-177a1ba0cb40

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jsign/verkle-vs-patricia
 go 1.19
 
 require (
-	github.com/crate-crypto/go-ipa v0.0.0-20220916134416-c5abbdbdf644
+	github.com/crate-crypto/go-ipa v0.0.0-20221107233728-e868de2bc50d
 	github.com/ethereum/go-ethereum v1.10.25
 	github.com/gballet/go-verkle v0.0.0-20220923150140-6c08cd337774
 	github.com/holiman/uint256 v1.2.0
@@ -23,7 +23,3 @@ require (
 
 // References https://github.com/gballet/go-ethereum/tree/beverly-hills-head, to have GetTreeKey func.
 replace github.com/ethereum/go-ethereum => github.com/gballet/go-ethereum v1.10.24-0.20221005144906-f0e4ab07b54a
-
-// References https://github.com/jsign/go-ipa/tree/jsign/upinv.
-// Remove this `replace` if the underlying PR get's merged.
-replace github.com/crate-crypto/go-ipa => github.com/jsign/go-ipa v0.0.0-20221107222631-177a1ba0cb40

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
+github.com/crate-crypto/go-ipa v0.0.0-20221107233728-e868de2bc50d h1:oKklxHtyPnuORKwwCcPqqMVJjC/s84JgUOhHnacwfWY=
+github.com/crate-crypto/go-ipa v0.0.0-20221107233728-e868de2bc50d/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -14,8 +16,6 @@ github.com/gballet/go-verkle v0.0.0-20220923150140-6c08cd337774 h1:e6wjiFtgxpaYd
 github.com/gballet/go-verkle v0.0.0-20220923150140-6c08cd337774/go.mod h1:A3FwOP19ARP2LMaO9gN/KrkiDTbmBOvCHlUy15YIXx0=
 github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
 github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
-github.com/jsign/go-ipa v0.0.0-20221107222631-177a1ba0cb40 h1:mGWXYmDBJeNDAZQcEn0i7tN+EBc4p+IzqQFT+9xwvLc=
-github.com/jsign/go-ipa v0.0.0-20221107222631-177a1ba0cb40/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
-github.com/crate-crypto/go-ipa v0.0.0-20220916134416-c5abbdbdf644 h1:1BOsVjUetPH2Lqv71Dh6uKLVj9WKdDr5KY57KZBbsWU=
-github.com/crate-crypto/go-ipa v0.0.0-20220916134416-c5abbdbdf644/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,6 +14,8 @@ github.com/gballet/go-verkle v0.0.0-20220923150140-6c08cd337774 h1:e6wjiFtgxpaYd
 github.com/gballet/go-verkle v0.0.0-20220923150140-6c08cd337774/go.mod h1:A3FwOP19ARP2LMaO9gN/KrkiDTbmBOvCHlUy15YIXx0=
 github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
 github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
+github.com/jsign/go-ipa v0.0.0-20221107222631-177a1ba0cb40 h1:mGWXYmDBJeNDAZQcEn0i7tN+EBc4p+IzqQFT+9xwvLc=
+github.com/jsign/go-ipa v0.0.0-20221107222631-177a1ba0cb40/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This PR shows how [the optimized `go-ipa` `Inverse(...)` code change](https://github.com/crate-crypto/go-ipa/pull/26) impacts benchmarks in this repo.

The raw `Inverse(...)` benchmark has the same expected speedup improvement as shown in the `go-ipa` benchmark:

```markdown
name                  old time/op    new time/op    delta
FpInverse/go-ipa-16     1.66µs ± 5%    1.12µs ± 2%  -32.34%  (p=0.000 n=15+13)
FpInverse/go-blst-16    1.42µs ± 1%    1.42µs ± 2%     ~     (p=0.955 n=13+15)
```

Regarding our other benchmark to specifically measure the performance of trie key generation:

```markdown
name                  old time/op    new time/op    delta
HashAddress/pedersen_hash-16    6.71µs ± 1%    6.08µs ± 2%  -9.40%  (p=0.000 n=12+15)
HashStorageSlot/pedersen_hash-16    8.45µs ± 3%    7.88µs ± 3%  -6.75%  (p=0.000 n=15+15)
```
So, we got around a **~1.09x speedup.**

And the quite exciting benchmark improvements for updating a Verkle Trie leaf:

```markdown
PedersenCommit/non_zero_entries=1-16               39.4µs ± 1%    38.0µs ± 2%   -3.59%  (p=0.000 n=14+15)
PedersenCommit/non_zero_entries=2-16               46.5µs ± 1%    45.2µs ± 1%   -2.73%  (p=0.000 n=15+15)
PedersenCommit/non_zero_entries=4-16               60.9µs ± 2%    59.3µs ± 2%   -2.56%  (p=0.000 n=15+13)
PedersenCommit/non_zero_entries=8-16               89.7µs ± 2%    87.7µs ± 1%   -2.17%  (p=0.000 n=14+12)
PedersenCommit/non_zero_entries=16-16               147µs ± 3%     146µs ± 2%     ~     (p=0.217 n=15+13)
PedersenCommit/non_zero_entries=32-16               265µs ± 3%     267µs ± 2%     ~     (p=0.425 n=15+14)
PedersenCommit/non_zero_entries=64-16               503µs ± 2%     508µs ± 1%     ~     (p=0.134 n=15+14)
PedersenCommit/non_zero_entries=128-16              988µs ± 1%     982µs ± 3%     ~     (p=0.474 n=11+15)
PedersenCommit/non_zero_entries=256-16             1.94ms ± 3%    1.96ms ± 1%   +1.00%  (p=0.009 n=15+14)
PedersenUpdateCommitment/vec_num_entries=1-16      13.9µs ± 2%     8.7µs ± 3%  -37.53%  (p=0.000 n=15+15)
PedersenUpdateCommitment/vec_num_entries=4-16      13.9µs ± 3%     8.7µs ± 3%  -37.60%  (p=0.000 n=15+15)
PedersenUpdateCommitment/vec_num_entries=16-16     14.1µs ± 1%     8.7µs ± 3%  -38.32%  (p=0.000 n=13+15)
PedersenUpdateCommitment/vec_num_entries=64-16     13.9µs ± 0%     8.6µs ± 2%  -37.69%  (p=0.000 n=11+12)
PedersenUpdateCommitment/vec_num_entries=256-16    14.0µs ± 0%     8.8µs ± 2%  -37.57%  (p=0.000 n=12+12)
```

This means that updating a Verkle Trie leaf got **~1.6x speedup**. This makes sense [as shown in my previous document](https://hackmd.io/fo9QphhdSnmeTRi8N-oC2A#Where-is-the-main-cost-in-this-case1) where the flamegraph shows that the cost was dominated by `Inverse(..)`. We also got a slight improvement in full Pedersen Commitment, but that operation is dominated by `Mul(...)`.

Note: I'll keep this as a draft PR until we have an idea if https://github.com/crate-crypto/go-ipa/pull/26 will get merged.